### PR TITLE
fix: handle missing credentials error

### DIFF
--- a/eodag_sentinelsat/eodag_sentinelsat.py
+++ b/eodag_sentinelsat/eodag_sentinelsat.py
@@ -336,8 +336,8 @@ class SentinelsatAPI(Api, QueryStringSearch, Download):
             try:
                 logger.debug("Initializing Sentinelsat API")
                 self.api = SentinelAPI(
-                    self.config.credentials["username"],
-                    self.config.credentials["password"],
+                    getattr(self.config, "credentials", {}).get("username", ""),
+                    getattr(self.config, "credentials", {}).get("password", ""),
                     self.config.endpoint,
                 )
                 # Use eodag progress bar which can be globally disabled


### PR DESCRIPTION
Missing credentials in configuration will result in:
```py
eodag.utils.exceptions.RequestError: Invalid user name or password. Note that account creation and password changes may take up to a week to propagate to the 'https://apihub.copernicus.eu/apihub/' API URL you are using. Consider switching to 'https://scihub.copernicus.eu/dhus/' instead in the mean time.
```
instead of
```py
AttributeError: 'PluginConfig' object has no attribute 'credentials'
```