### PR TITLE
fix: queryable id and metadata mapping update

### DIFF
--- a/eodag_sentinelsat/providers.yml
+++ b/eodag_sentinelsat/providers.yml
@@ -32,7 +32,9 @@ api: !plugin
     metadata_path: '$.*'
   metadata_mapping:
     acquisitionType: '$.acquisitiontype'
-    id: '$.uuid'
+    id:
+      - filename
+      - '$.identifier'
     uuid:
       - uuid
       - '$.uuid'

--- a/eodag_sentinelsat/providers.yml
+++ b/eodag_sentinelsat/providers.yml
@@ -48,9 +48,7 @@ api: !plugin
     platformSerialIdentifier: '$.platformserialidentifier'
     instrument: '$.instrumentname'
     processingLevel: '$.processinglevel'
-    title:
-      - title
-      - '$.title'
+    title: '$.title'
     abstract: '$.summary'
     orbitNumber:
       - orbitnumber
@@ -58,6 +56,9 @@ api: !plugin
     orbitDirection:
       - orbitdirection
       - '$.orbitdirection'
+    swathIdentifier:
+      - swathIdentifier
+      - '$.swathIdentifier'
     cloudCover:
       - cloudcoverpercentage
       - '$.cloudcoverpercentage'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,13 +16,13 @@ def download_dir():
 
 @pytest.fixture
 def logging_info():
-    setup_logging(1)
+    setup_logging(2)
     yield
-    setup_logging(0)
+    setup_logging(1)
 
 
 @pytest.fixture
 def logging_debug():
     setup_logging(3)
     yield
-    setup_logging(0)
+    setup_logging(1)


### PR DESCRIPTION
Metadata mapping update, enabling the possibility to search for a product by its id:
```py
from eodag import EODataAccessGateway
dag = EODataAccessGateway()
dags_L1C, _ = dag.search(id='S2B_MSIL1C_20200813T104629_N0209_R051_T31TCJ_20200813T130127')
```