### PR TITLE
fix: lta products handling with sentinelsat v1.1.0

### DIFF
--- a/eodag_sentinelsat/eodag_sentinelsat.py
+++ b/eodag_sentinelsat/eodag_sentinelsat.py
@@ -261,7 +261,8 @@ class SentinelsatAPI(Api, QueryStringSearch, Download):
         :param dict kwargs: ``outputs_prefix`` (str), ``extract`` (bool)  can be provided
                             here and will override any other values defined in a
                             configuration file or with environment variables.
-                            ``checksum`` can be passed to ``sentinelsat.download_all`` directly
+                            ``checksum``, ``max_attempts``, ``n_concurrent_dl``, ``fail_fast``
+                            and ``node_filter`` can be passed to ``sentinelsat.download_all`` directly
                             which is used under the hood.
         :returns: The absolute path to the downloaded product in the local filesystem
         :rtype: str
@@ -307,8 +308,8 @@ class SentinelsatAPI(Api, QueryStringSearch, Download):
         :param dict kwargs: ``outputs_prefix`` (str), ``extract`` (bool)  can be provided
                             here and will override any other values defined in a
                             configuration file or with environment variables.
-                            ``checksum``, ``max_attempts`` and ``n_concurrent_dl``
-                            can be passed to ``sentinelsat.download_all`` directly.
+                            ``checksum``, ``max_attempts``, ``n_concurrent_dl``, ``fail_fast``
+                            and ``node_filter`` can be passed to ``sentinelsat.download_all`` directly.
         :return: A collection of absolute paths to the downloaded products
         :rtype: list
         """
@@ -336,7 +337,14 @@ class SentinelsatAPI(Api, QueryStringSearch, Download):
             sentinelsat_kwargs = {
                 k: kwargs.pop(k)
                 for k in list(kwargs)
-                if k in ["checksum", "max_attempts", "n_concurrent_dl"]
+                if k
+                in [
+                    "max_attempts",
+                    "checksum",
+                    "n_concurrent_dl",
+                    "fail_fast",
+                    "nodefilter",
+                ]
             }
 
             if progress_callback is None:

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         "sentinelsat",
         "eodag >= 2.3.0b1",
         "python-dateutil",
-        "tenacity",
     ],
     extras_require={
         "dev": [

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -34,7 +34,7 @@ def test_end_to_end_complete_scihub(dag, download_dir):
     """Complete end-to-end test with SCIHUB for search, download and download_all"""
     # Search for products that are ONLINE and as small as possible
     today = datetime.date.today()
-    month_span = datetime.timedelta(weeks=4)
+    month_span = datetime.timedelta(weeks=2)
     search_results, _ = dag.search(
         productType="S2_MSI_L1C",
         start=(today - month_span).isoformat(),


### PR DESCRIPTION
Fixes #31

`OFFLINE` products download retry is handled from `sentinelsat`, but it is also more integrated to `eodag`, to align with other providers, and have more information logged during the download retry:
- `wait` and `timeout` parameters passed to [`download()`](https://eodag.readthedocs.io/en/latest/api_reference/core.html#eodag.api.core.EODataAccessGateway.download) or [`download_all()`](https://eodag.readthedocs.io/en/latest/api_reference/core.html#eodag.api.core.EODataAccessGateway.download_all) methods will be used to handle retry loops. `wait` parameter will be sent to `sentinelsat` as `lta_retry_delay` and  `timeout` as `lta_timeout`.
&rarr; A loop will retry downloading every `wait` minutes (default 2') until `timeout` minutes (default 20'). (info displayed in logs)
- In addition, to prevent users to think that the download freezes, an info message is logged: *"Once ordered, OFFLINE/LTA product download retries may not be logged"*.
- `sentinelsat` progress bars wrapped and handled from `eodag` to avoid bars duplication at each retry loop